### PR TITLE
Fix diff export redaction for sensitive values

### DIFF
--- a/envsnap/cli_diff_export.py
+++ b/envsnap/cli_diff_export.py
@@ -27,11 +27,11 @@ def cmd_diff_export(args: argparse.Namespace) -> None:
 
     fmt = args.format.lower()
     if fmt == "json":
-        output = to_json(result, indent=args.indent)
+        output = to_json(result, indent=args.indent, redact_sensitive=args.redact)
     elif fmt == "csv":
-        output = to_csv(result)
+        output = to_csv(result, redact_sensitive=args.redact)
     elif fmt == "markdown":
-        output = to_markdown(result)
+        output = to_markdown(result, redact_sensitive=args.redact)
     else:
         print(f"error: unknown format '{fmt}'. Choose json, csv, or markdown.", file=sys.stderr)
         sys.exit(1)
@@ -64,6 +64,11 @@ def build_parser(parent: argparse._SubParsersAction | None = None) -> argparse.A
         type=int,
         default=2,
         help="JSON indentation level (default: 2).",
+    )
+    parser.add_argument(
+        "--redact",
+        action="store_true",
+        help="Mask sensitive-key values before exporting the diff.",
     )
     parser.add_argument(
         "--output", "-o",

--- a/envsnap/env_diff_export.py
+++ b/envsnap/env_diff_export.py
@@ -4,72 +4,123 @@ from __future__ import annotations
 import csv
 import io
 import json
-from typing import List
+from copy import deepcopy
+from typing import List, Tuple
 
 from envsnap.diff import DiffResult
+from envsnap.redact import redact
 
 
-def to_json(result: DiffResult, indent: int = 2) -> str:
+def _labels(result: DiffResult) -> Tuple[str, str]:
+    return result.get("label_a") or "A", result.get("label_b") or "B"
+
+
+def _changed_values(value) -> Tuple[str, str]:
+    """Return before/after values for either legacy tuple or compare() dict shapes."""
+    if isinstance(value, dict):
+        return value.get("before"), value.get("after")
+    before, after = value
+    return before, after
+
+
+def redacted_result(result: DiffResult, placeholder: str = "<redacted>") -> DiffResult:
+    """Return a copy of *result* with sensitive-key values masked.
+
+    This keeps the export layer safe for JSON/CSV/Markdown callers that use the
+    lower-level diff result directly instead of the human compare_report path.
+    """
+    masked = deepcopy(result)
+
+    for section in ("added", "removed", "unchanged"):
+        values = masked.get(section, {})
+        if values:
+            masked[section] = redact(values, placeholder=placeholder)
+
+    changed = {}
+    for key, value in masked.get("changed", {}).items():
+        before, after = _changed_values(value)
+        redacted_pair = redact({key: before, f"{key}__after": after}, placeholder=placeholder)
+        if isinstance(value, dict):
+            changed[key] = {
+                **value,
+                "before": redacted_pair[key],
+                "after": redacted_pair[f"{key}__after"],
+            }
+        else:
+            changed[key] = (redacted_pair[key], redacted_pair[f"{key}__after"])
+    masked["changed"] = changed
+
+    return DiffResult(**masked)
+
+
+def to_json(result: DiffResult, indent: int = 2, redact_sensitive: bool = False) -> str:
     """Serialise a DiffResult to a JSON string."""
+    if redact_sensitive:
+        result = redacted_result(result)
+    label_a, label_b = _labels(result)
     data = {
-        "label_a": result.label_a,
-        "label_b": result.label_b,
-        "added": result.added,
-        "removed": result.removed,
+        "label_a": label_a,
+        "label_b": label_b,
+        "added": result.get("added", {}),
+        "removed": result.get("removed", {}),
         "changed": [
             {"key": k, "before": before, "after": after}
-            for k, (before, after) in result.changed.items()
+            for k, value in result.get("changed", {}).items()
+            for before, after in [_changed_values(value)]
         ],
-        "unchanged": list(result.unchanged.keys()),
+        "unchanged": list(result.get("unchanged", {}).keys()),
     }
     return json.dumps(data, indent=indent, sort_keys=True)
 
 
-def to_csv(result: DiffResult) -> str:
+def to_csv(result: DiffResult, redact_sensitive: bool = False) -> str:
     """Serialise a DiffResult to a CSV string with columns: status, key, before, after."""
+    if redact_sensitive:
+        result = redacted_result(result)
     buf = io.StringIO()
     writer = csv.writer(buf)
     writer.writerow(["status", "key", "before", "after"])
 
-    for key in sorted(result.added):
-        writer.writerow(["added", key, "", result.added[key]])
+    for key in sorted(result.get("added", {})):
+        writer.writerow(["added", key, "", result["added"][key]])
 
-    for key in sorted(result.removed):
-        writer.writerow(["removed", key, result.removed[key], ""])
+    for key in sorted(result.get("removed", {})):
+        writer.writerow(["removed", key, result["removed"][key], ""])
 
-    for key in sorted(result.changed):
-        before, after = result.changed[key]
+    for key in sorted(result.get("changed", {})):
+        before, after = _changed_values(result["changed"][key])
         writer.writerow(["changed", key, before, after])
 
-    for key in sorted(result.unchanged):
-        writer.writerow(["unchanged", key, result.unchanged[key], result.unchanged[key]])
+    for key in sorted(result.get("unchanged", {})):
+        writer.writerow(["unchanged", key, result["unchanged"][key], result["unchanged"][key]])
 
     return buf.getvalue()
 
 
-def to_markdown(result: DiffResult) -> str:
+def to_markdown(result: DiffResult, redact_sensitive: bool = False) -> str:
     """Serialise a DiffResult to a Markdown table."""
+    if redact_sensitive:
+        result = redacted_result(result)
     lines: List[str] = []
-    label_a = result.label_a or "A"
-    label_b = result.label_b or "B"
+    label_a, label_b = _labels(result)
 
     lines.append(f"## Diff: `{label_a}` → `{label_b}`")
     lines.append("")
     lines.append("| Status | Key | Before | After |")
     lines.append("|--------|-----|--------|-------|")
 
-    for key in sorted(result.added):
-        lines.append(f"| added | `{key}` | | `{result.added[key]}` |")
+    for key in sorted(result.get("added", {})):
+        lines.append(f"| added | `{key}` | | `{result['added'][key]}` |")
 
-    for key in sorted(result.removed):
-        lines.append(f"| removed | `{key}` | `{result.removed[key]}` | |")
+    for key in sorted(result.get("removed", {})):
+        lines.append(f"| removed | `{key}` | `{result['removed'][key]}` | |")
 
-    for key in sorted(result.changed):
-        before, after = result.changed[key]
+    for key in sorted(result.get("changed", {})):
+        before, after = _changed_values(result["changed"][key])
         lines.append(f"| changed | `{key}` | `{before}` | `{after}` |")
 
-    for key in sorted(result.unchanged):
-        v = result.unchanged[key]
+    for key in sorted(result.get("unchanged", {})):
+        v = result["unchanged"][key]
         lines.append(f"| unchanged | `{key}` | `{v}` | `{v}` |")
 
     return "\n".join(lines) + "\n"

--- a/envsnap/redact.py
+++ b/envsnap/redact.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from typing import Dict, List, Tuple
 
 DEFAULT_SENSITIVE_SUBSTRINGS: List[str] = [
+    "DATABASE_URL",
     "SECRET",
     "PASSWORD",
     "PASSWD",

--- a/tests/test_env_diff_export.py
+++ b/tests/test_env_diff_export.py
@@ -65,6 +65,28 @@ def test_to_json_custom_indent():
     assert "    " in output
 
 
+def test_to_json_redacts_sensitive_added_removed_and_changed_values():
+    r = _result(
+        added={"AWS_SECRET_ACCESS_KEY": "added-secret"},
+        removed={"DATABASE_PASSWORD": "removed-secret"},
+        changed={"API_TOKEN": ("old-token", "new-token")},
+    )
+    data = json.loads(to_json(r, redact_sensitive=True))
+    assert data["added"]["AWS_SECRET_ACCESS_KEY"] == "<redacted>"
+    assert data["removed"]["DATABASE_PASSWORD"] == "<redacted>"
+    assert data["changed"] == [{"key": "API_TOKEN", "before": "<redacted>", "after": "<redacted>"}]
+    assert "added-secret" not in json.dumps(data)
+    assert "removed-secret" not in json.dumps(data)
+    assert "old-token" not in json.dumps(data)
+    assert "new-token" not in json.dumps(data)
+
+
+def test_to_json_handles_compare_dict_changed_shape_with_redaction():
+    r = _result(changed={"DATABASE_URL": {"before": "postgres://old", "after": "postgres://new"}})
+    data = json.loads(to_json(r, redact_sensitive=True))
+    assert data["changed"] == [{"key": "DATABASE_URL", "before": "<redacted>", "after": "<redacted>"}]
+
+
 # --- to_csv ---
 
 def _parse_csv(text: str):

--- a/tests/test_redact.py
+++ b/tests/test_redact.py
@@ -19,6 +19,7 @@ ENV = {
         ("DATABASE_PASSWORD", True),
         ("GITHUB_TOKEN", True),
         ("AUTH_HEADER", True),
+        ("DATABASE_URL", True),
         ("APP_NAME", False),
         ("PORT", False),
     ],


### PR DESCRIPTION
Fixes #9

## Summary
- add redaction support to diff export serialization before JSON/CSV/Markdown values are formatted
- make `DATABASE_URL` part of the default sensitive-key detection set
- cover JSON export redaction for added/removed/changed fake secret values, including the dict-shaped `compare()` changed payload

## Verification
- `python3 -m py_compile envsnap/env_diff_export.py envsnap/cli_diff_export.py tests/test_env_diff_export.py`
- `/tmp/envsnap-venv/bin/python -m pytest tests/test_env_diff_export.py tests/test_redact.py -q` (32 passed)
- `git diff --check`

Safety: public-code-only change using fake secret fixtures; no real env snapshots, secrets, private CI logs, production access, paid tooling, deploys, or spend.